### PR TITLE
Minor additions for ProLiant redfish fw

### DIFF
--- a/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/RedHxServerConnectionContext.java
+++ b/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/RedHxServerConnectionContext.java
@@ -16,6 +16,7 @@
 
 package org.redhelix.server.main;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.olingo.client.api.communication.request.retrieve.ODataEntityRequest;
 import org.apache.olingo.client.api.domain.ClientEntity;
 import org.apache.olingo.client.api.ODataClient;
@@ -60,12 +61,23 @@ public final class RedHxServerConnectionContext
         this.client                 = null;
     }
 
+    private ODataEntityRequest<ClientEntity> RedHxServerSetAuth(ODataEntityRequest<ClientEntity> req)
+    {
+        String username = System.getProperty("param_username");
+        String password = System.getProperty("param_password");
+        String authorization = "Basic ";
+        authorization += new String(Base64.encodeBase64((username + ":" + password).getBytes()));
+        req.addCustomHeader("Authorization", authorization);
+
+        return req;
+    }
+
     public ODataEntityRequest<ClientEntity> getChassisEntityRequest( )
     {
         URI                              chassisUri = serviceRootLocator.getUri(RedHxServiceRootIdEum.CHASSIS);
         ODataEntityRequest<ClientEntity> req        = client.getRetrieveRequestFactory().getEntityRequest(chassisUri);
 
-        return req;
+        return RedHxServerSetAuth(req);
     }
 
     public ODataEntityRequest<ClientEntity> getEntityRequest( RedHxUriPath pathToResource )
@@ -74,7 +86,7 @@ public final class RedHxServerConnectionContext
         URI                              myUri = serviceRootLocator.getUri(pathToResource.getValue());
         ODataEntityRequest<ClientEntity> req   = client.getRetrieveRequestFactory().getEntityRequest(myUri);
 
-        return req;
+        return RedHxServerSetAuth(req);
     }
 
     public RedHxRedfishProtocolVersionEnum getRedfishProtocolVersion( )

--- a/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/RedMatrixServerDb.java
+++ b/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/RedMatrixServerDb.java
@@ -54,7 +54,15 @@ public class RedMatrixServerDb
          */
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel",
                            "error");
-
+        
+        String protocol = System.getProperty("param_protocol");
+        String hostname = System.getProperty("param_hostname");
+        String port = System.getProperty("param_port");
+        String prefix = System.getProperty("param_prefix");
+        int portNum = 0;
+        if(port != null)
+            portNum = Integer.parseInt(port);
+        
         /*
          * create a communication context that will be used to talk with a single Redfish server. This does not
          * allocate and nextwork sockets.
@@ -67,10 +75,10 @@ public class RedMatrixServerDb
              * open a HTTP connection to the Redfish server provided by the DMTF mockup. The mockup server is started with the command "node
              * server.js"
              */
-            ctx.openConnection(RedHxTcpProtocolTypeEnum.HTTP,
-                               "localhost",
-                               9080,
-                               "mockup1");
+            ctx.openConnection((protocol == "https") ? RedHxTcpProtocolTypeEnum.HTTPS : RedHxTcpProtocolTypeEnum.HTTP ,
+                               hostname,
+                               portNum,
+                               prefix);
 
             Set<RedHxUriPath> chassisPathSet;
 

--- a/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/ServiceRootReader.java
+++ b/redhx-build-all/redhx-app-server-db/src/main/java/org/redhelix/server/main/ServiceRootReader.java
@@ -53,7 +53,7 @@ import java.util.TreeMap;
  */
 class ServiceRootReader
 {
-    private static final String ENTITY_SET_NAME = "odata";    // from the Redfish specification.
+    private static final String ENTITY_SET_NAME = "odata/";    // from the Redfish specification.
 
     /**
      * each KEY coresponds to a Redfish schema and each schema has a JSON file provided by Redfish
@@ -105,11 +105,13 @@ class ServiceRootReader
                 redfishProtocolVersion);
         final String serviceRootStr      = serviceRoot.getServiceRootString();
         final URI    redfishEntitySetURI = client.newURIBuilder(serviceRootStr).appendEntitySetSegment(ENTITY_SET_NAME).build();
-
+        
+        client.getConfiguration().setGzipCompression(true);
         client.getRetrieveRequestFactory();
 
         final ODataRetrieveResponse<ClientEntitySet> serviceRootResponse =
             client.getRetrieveRequestFactory().getEntitySetRequest(redfishEntitySetURI).execute();
+            
         final List<ClientEntity> list;
         final String             tcpProtocolStr;
 

--- a/redhx-build-all/redhx-core-impl/src/main/java/org/redhelix/core/root/RedHxServiceRootIdImpl.java
+++ b/redhx-build-all/redhx-core-impl/src/main/java/org/redhelix/core/root/RedHxServiceRootIdImpl.java
@@ -42,24 +42,30 @@ public final class RedHxServiceRootIdImpl
     {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("http://");    // Redfish spec mandates the Service Root is always reachable by the http
+        if(httpProtocol == RedHxTcpProtocolTypeEnum.HTTPS)
+            sb.append("https://");
+        else
+            sb.append("http://");    // Redfish spec mandates the Service Root is always reachable by the http
 
         // protocol.
         sb.append(hostName);
-        sb.append(":");
-        sb.append(tcpPortNumber);
+        if(tcpPortNumber != 0)
+        {
+            sb.append(":");
+            sb.append(tcpPortNumber);
+        }
+        sb.append("/");
 
         if (servicePrefix != null)
         {
-            sb.append("/");
             sb.append(servicePrefix);
         }
 
-        sb.append("/redfish/");
+        sb.append("redfish/");
 
         if (redfishProtocolVersion == RedHxRedfishProtocolVersionEnum.VERSION_1)
         {
-            sb.append("v1");
+            sb.append("v1/");
         }
         else
         {
@@ -67,7 +73,6 @@ public final class RedHxServiceRootIdImpl
                                                + " is recoganized.");
         }
 
-        sb.append("/");
         serviceRootStr = sb.toString();
     }
 

--- a/winBuild.cmd
+++ b/winBuild.cmd
@@ -1,0 +1,23 @@
+:: [rights]  Copyright Hewlett-Packard Enterprise 2015 https://www.hpe.com
+:: [license] Licensed under Apache 2.0 https://www.apache.org/licenses/LICENSE-2.0
+:: [author]  Dan Bryant https://github.com/DanHP
+
+@echo off
+setlocal
+(call mvn -v 1>NUL 2>NUL) || (
+  echo ERR Apache Maven is required to build
+  echo     see https://maven.apache.org/download.cgi
+  exit /b 1
+)
+cd redhx-build-all
+(call mvn package) || (
+  echo ERR Maven build failed
+  exit /b 2
+)
+(where robocopy 1>NUL 2>NUL) || (
+  echo ERR Robocopy is required to build
+  echo     This is usually in all windows installs
+  exit /b 3
+)
+for /f %%p in ('dir /s/b %userprofile%\.m2\repository\*.jar *.jar') do @robocopy /njh /njs /ndl /fp "%%~dpp." "..\jars" "%%~nxp" /xf commons-lang3-3.1.jar
+endlocal

--- a/winRun.cmd
+++ b/winRun.cmd
@@ -1,0 +1,40 @@
+:: [rights]  Copyright Hewlett-Packard Enterprise 2015 https://www.hpe.com
+:: [license] Licensed under Apache 2.0 https://www.apache.org/licenses/LICENSE-2.0
+:: [author]  Dan Bryant https://github.com/DanHP
+@echo off
+setlocal
+
+::### Change these lines to reflect your config ###::
+set server=%myserver%
+set port=443
+set username=bob
+set password=secret
+
+set cert=server.crt
+set keystore=cacerts.jks
+if not exist %keystore% (
+  (openssl version 1>NUL 2>NUL) || (
+    echo ERR OpenSSL is required to build the Java Keystore
+    echo     see Cygwin for a collection of linux binaries including OpenSSL
+    echo     link https://cygwin.com/
+    exit /b 1
+  )
+  echo ### CREATING KEYSTORE FOR SSL VALIDATION ###
+  (echo QUIT | openssl s_client -connect %server%:%port% 2>NUL | openssl x509 -out %cert%) || (
+    echo ERR Failed to download the server cert
+    exit /b 2
+  )
+  (echo yes | keytool -import -v -trustcacerts -alias server-alias -file %cert% -keystore %keystore% -keypass %password% -storepass %password%) || (
+    echo ERR Failed to create the keystore
+    exit /b 3
+  )
+)
+cd redhx-build-all
+java ^
+ "-Dparm_protocol=https" ^
+ "-Dparam_hostname=%server%" ^
+ "-Dparam_username=%username%" ^
+ "-Dparam_password=%password%" ^
+ "-Djavax.net.ssl.trustStore=%cd%\..\%keystore%" ^
+ -cp "..\jars\*" org.redhelix.server.main.RedMatrixServerDb
+endlocal


### PR DESCRIPTION
Made some additions for smoother execution against ProLiant redfish fw:
1. Added scripts to build / run with cert-store creation.  Getting the certs lined up can be laborious.
2. Added BasicAuth capabilities authenticated SSL based GETs.
3. Added support for compressed (Gziip) content on HTTPS response.
4. Tightened the URL parsing to avoid redirects

Note... I didn't add full support for 3xx redirects.  This will likely want to be addressed eventually, but I wanted to have a small change deck for this pull request. 
